### PR TITLE
Bump python versions and automate versioning

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         os: [ubuntu-latest]
     env:
       OS: ${{ matrix.os }}

--- a/plantcv/annotate/__init__.py
+++ b/plantcv/annotate/__init__.py
@@ -1,3 +1,3 @@
 from importlib.metadata import version
 # Auto versioning
-__version__ = version("annotate")
+__version__ = version("plantcv-annotate")

--- a/plantcv/annotate/__init__.py
+++ b/plantcv/annotate/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+# Auto versioning
+__version__ = version("annotate")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 64.0", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -26,7 +26,15 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
+
 [project.urls]
 Homepage = "https://plantcv.org"
 Documentation = "https://plantcv.readthedocs.io"
 Repository = "https://github.com/danforthcenter/plantcv-annotate"
+
+[tool.setuptools_scm]


### PR DESCRIPTION
**Describe your changes**
Bumps supported Python versions (through testing) to 3.9, 3.10, and 3.11. Adds automated versioning using `setuptools-scm`

**Type of update**
Is this a: New feature or feature enhancement

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `updating.md`
- [ ] Code reviewed
- [ ] PR approved
