### PR TITLE
update napari_open

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented below.
 
-#### annotate.get_centroids**
+#### annotate.get_centroids
 
 * v0.1dev: coords_list = **annotate.get_centroids**(*bin_img*)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,27 @@
 ## Changelog
 
 All notable changes to this project will be documented below.
+
+#### annotate.get_centroids**
+
+* v0.1dev: coords_list = **annotate.get_centroids**(*bin_img*)
+
+#### annotate.napari_classes
+
+* v0.1dev: class_list = **annotate.napari_classes**(*viewer*)
+
+#### annotate.napari_join_labels
+
+* v0.1dev: relabeled_mask, mask_dict = **annotate.napari_join_labels**(*img, viewer*)
+
+#### annotate.napari_label_classes
+
+* v0.1dev: viewer = **annotate.napari_label_classes**(*img, classes, show=True*)
+
+#### annotate.napari_open
+
+* v0.1dev: viewer = **annotate.napari_open**(*img, mode = 'native', show=True*)
+
+#### annotate.Points
+
+* v0.1dev: viewer = **annotate.Points**(*img, figsize=(12,6), label="dafault"*)

--- a/docs/napari_open.md
+++ b/docs/napari_open.md
@@ -1,14 +1,14 @@
 ## Open Image with Napari
 
-Open image data (e.g. RGB, gray, hyperspectral) with an interactive Napari viewer. If a gray image is opened, the image will be pseudocolored for better visualization.
+Open image data (e.g. RGB, gray, hyperspectral) with an interactive Napari viewer. Labeled masks may be colorized for better visualization. 
 
-**plantcv.annotate.napari_open**(*img, mode = 'native', show=True*)
+**plantcv.annotate.napari_open**(*img, mode='native', show=True*)
 
 **returns** napari viewer object
 
 - **Parameters:**
-    - img - image data (compatible with gray, RGB, and hyperspectral data. If data is hyperspecral it should be the array e.g. hyperspectral.array_data)
-    - mode - 'native' or 'colorize'. If 'colorized' is selected grayimages will be colorized.
+    - img - image data (compatible with gray, RGB, and hyperspectral data. If data is hyperspecral it should be the array e.g. `hyperspectral.array_data`)
+    - mode - 'native' or 'colorize'. If 'colorized' is selected gray images will be colorized.
     - show - if show = True, viewer is launched. False setting is useful for test purposes.
 
 - **Context:**

--- a/docs/napari_open.md
+++ b/docs/napari_open.md
@@ -2,12 +2,13 @@
 
 Open image data (e.g. RGB, gray, hyperspectral) with an interactive Napari viewer. If a gray image is opened, the image will be pseudocolored for better visualization.
 
-**plantcv.annotate.napari_open**(*img, show=True*)
+**plantcv.annotate.napari_open**(*img, mode = 'native', show=True*)
 
 **returns** napari viewer object
 
 - **Parameters:**
     - img - image data (compatible with gray, RGB, and hyperspectral data. If data is hyperspecral it should be the array e.g. hyperspectral.array_data)
+    - mode - 'native' or 'colorize'. If 'colorized' is selected grayimages will be colorized.
     - show - if show = True, viewer is launched. False setting is useful for test purposes.
 
 - **Context:**
@@ -24,7 +25,7 @@ import plantcv.annotate as pcvan
 # Create an instance of the Points class
 img, path, name = pcv.readimage("./grayimg.png")
 
-viewer = pcvan.napari_open(img=img)
+viewer = pcvan.napari_open(img=img, mode='colorize')
 
 # Should open interactive napari viewer
 

--- a/plantcv/annotate/napari_open.py
+++ b/plantcv/annotate/napari_open.py
@@ -6,13 +6,14 @@ from skimage.color import label2rgb
 import napari
 
 
-def napari_open(img, show=True):
+def napari_open(img, mode='native', show=True):
     """
     open img in napari
 
     Inputs:
     img  = img  (grayimg, rgbimg, or hyperspectral image array data e.g.
     hyperspectraldata.array_data)
+    mode = 'native or 'colorize'
     show = if show is True the viewer is launched. This option is useful for
     running tests without triggering the viewer.
 
@@ -25,9 +26,10 @@ def napari_open(img, show=True):
     """
     shape = np.shape(img)
     if len(shape) == 2:
-        colorful = label2rgb(img)
-        img = (255*colorful).astype(np.uint8)
-        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if mode == 'colorize':
+            colorful = label2rgb(img)
+            img = (255*colorful).astype(np.uint8)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     if len(shape) == 3:
         if shape[2] == 3:
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

--- a/plantcv/annotate/napari_open.py
+++ b/plantcv/annotate/napari_open.py
@@ -25,11 +25,10 @@ def napari_open(img, mode='native', show=True):
 
     """
     shape = np.shape(img)
-    if len(shape) == 2:
-        if mode == 'colorize':
-            colorful = label2rgb(img)
-            img = (255*colorful).astype(np.uint8)
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    if len(shape) == 2 and mode == 'colorize':
+        colorful = label2rgb(img)
+        img = (255*colorful).astype(np.uint8)
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
     if len(shape) == 3:
         if shape[2] == 3:
             img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)

--- a/plantcv/annotate/napari_open.py
+++ b/plantcv/annotate/napari_open.py
@@ -7,22 +7,22 @@ import napari
 
 
 def napari_open(img, mode='native', show=True):
-    """
-    open img in napari
+    """Open an image with a napari interactive viewer
 
-    Inputs:
-    img  = img  (grayimg, rgbimg, or hyperspectral image array data e.g.
-    hyperspectraldata.array_data)
-    mode = 'native or 'colorize'
-    show = if show is True the viewer is launched. This option is useful for
+    Parameters
+    ----------
+    img : numpy.ndarray
+        Image to be opened, img can be gray, rgb, or multispectral
+    mode: str
+        Viewing mode, either 'native' (default) or 'colorize'
+    show: bool
+        if show is True the viewer is launched. This option is useful for
     running tests without triggering the viewer.
 
-    Returns:
-    viewer  = napari viewer object
-
-    :param img: numpy.ndarray
-    :return viewer: napari viewer object
-
+    Returns
+    -------
+    napari.viewer.Viewer
+        Napari viewer object
     """
     shape = np.shape(img)
     if len(shape) == 2 and mode == 'colorize':

--- a/tests/test_napari_open.py
+++ b/tests/test_napari_open.py
@@ -29,6 +29,19 @@ def test_napari_open_gray(test_data):
     viewer.close()
 
 
+def test_napari_open_gray1(test_data):
+    """Test for PlantCV.Annotate"""
+    # Read in test data
+    img, _, _ = readimage(test_data.kmeans_seed_gray_img)
+    viewer = napari_open(img, mode='colorize', show=False)
+    coor = [(25, 25), (50, 50)]
+    viewer.add_points(np.array(coor), symbol="o", name="total",
+                      face_color="red", size=1)
+
+    assert len(viewer.layers['total'].data) == 2
+    viewer.close()
+
+
 def test_napari_open_envi(test_data):
     """Test for PlantCV.Annotate"""
     # Read in test data


### PR DESCRIPTION
update napari_open function tests and docs so the default behavior is not to colorize gray images by adding  a mode option.

**Describe your changes**
update napari_open function tests and docs so the default behavior is not to colorize gray images by adding  a mode option.


**Type of update**
Is this a:
* New feature or feature enhancement
* Update to documentation

**Associated issues**
https://github.com/danforthcenter/plantcv-annotate/issues/35

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [x] PR functionality reviewed in a Jupyter Notebook
- [x] All tests pass
- [x] Test coverage remains 100%
- [x] Documentation tested
- [x] New documentation pages added to `plantcv/mkdocs.yml`
- [x] Changes to function input/output signatures added to `updating.md`
- [x] Code reviewed
- [x] PR approved
