### PR TITLE
Update border_color in napari_label_classes.py

### DIFF
--- a/plantcv/annotate/napari_label_classes.py
+++ b/plantcv/annotate/napari_label_classes.py
@@ -82,7 +82,7 @@ def napari_label_classes(img, classes=False, size=10,
         for x in classes:
             if x not in keys:
                 viewer.add_points(np.array([]), name=x, symbol='square',
-                                  edge_color=random.choice(color),
+                                  border_color=random.choice(color),
                                   face_color=random.choice(color), size=size)
         keys = napari_classes(viewer)
 
@@ -95,7 +95,7 @@ def napari_label_classes(img, classes=False, size=10,
                 else:
                     viewer.add_points(importdata[key], name=key,
                                       symbol='square',
-                                      edge_color=random.choice(color),
+                                      border_color=random.choice(color),
                                       face_color=random.choice(color),
                                       size=size)
 


### PR DESCRIPTION
**Describe your changes**
Napari has removed the parameter `edge_color`, which was used in `napari_label_classes`. This PR changes that parameter to the new `border_color` instead. 

**Type of update**
Is this a:
* Bug fix


**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
