### PR TITLE
Napari deprecation updates

### DIFF
--- a/plantcv/annotate/napari_label_classes.py
+++ b/plantcv/annotate/napari_label_classes.py
@@ -82,7 +82,7 @@ def napari_label_classes(img, classes=False, size=10,
         for x in classes:
             if x not in keys:
                 viewer.add_points(np.array([]), name=x, symbol='square',
-                                  edge_color=random.choice(color),
+                                  border_color=random.choice(color),
                                   face_color=random.choice(color), size=size)
         keys = napari_classes(viewer)
 
@@ -95,7 +95,7 @@ def napari_label_classes(img, classes=False, size=10,
                 else:
                     viewer.add_points(importdata[key], name=key,
                                       symbol='square',
-                                      edge_color=random.choice(color),
+                                      border_color=random.choice(color),
                                       face_color=random.choice(color),
                                       size=size)
 

--- a/tests/test_napari_classes.py
+++ b/tests/test_napari_classes.py
@@ -1,14 +1,13 @@
 import numpy as np
-from plantcv.annotate import napari_classes
+from plantcv.annotate import napari_classes, napari_open
 
 
-def test_napari_classes(make_napari_viewer):
+def test_napari_classes():
     """Test for PlantCV.Annotate"""
     # Read in test data
-    viewer = make_napari_viewer(show=False)
     img = np.zeros((100, 100))
     coor = [(25, 25), (50, 50)]
-    viewer.add_image(img)
+    viewer = napari_open(img, show=False)
     viewer.add_points(np.array(coor), symbol="square", name="total",
                       face_color="red", size=30)
     viewer.add_points(np.array(coor), symbol="square", name="test",


### PR DESCRIPTION
**Describe your changes**
In napari, the `edge_color` attribute for layers like Points and Shapes has been deprecated as of napari 0.5.0. It has been renamed to `border_color`. This PR renames the keyword arguments. 


**Type of update**
Is this a:
* update

**Associated issues**
Reference associated issue numbers. Does this pull request close any issues?

**Additional context**
https://napari.org/dev/api/napari.Viewer.html#napari.Viewer.add_points

**For the reviewer**
See [this page](https://plantcv.readthedocs.io/en/latest/pr_review_process/) for instructions on how to review the pull request.
- [ ] PR functionality reviewed in a Jupyter Notebook
- [ ] All tests pass
- [ ] Test coverage remains 100%
- [ ] Documentation tested
- [ ] New documentation pages added to `plantcv/mkdocs.yml`
- [ ] Changes to function input/output signatures added to `changelog.md`
- [ ] Code reviewed
- [ ] PR approved
